### PR TITLE
Réaligner les templates de configuration de test avec les modules Dynaconf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,10 +90,14 @@ export DB_HOST DB_PORT DB_NAME DB_GROUP DB_USER DB_PW
 ENVSUBST_VARS = $${VN_SITE_URL} $${VN_USER_EMAIL} $${VN_USER_PW} $${VN_CLIENT_KEY} $${VN_CLIENT_SECRET} $${DB_HOST} $${DB_PORT} $${DB_NAME} $${DB_GROUP} $${DB_USER} $${DB_PW}
 
 .PHONY: test-config
-test-config: ## Render ~/.evn_test.{yaml,toml} from templates and VN_*/DB_* env vars
+test-config: ## Render the test configuration files from templates and VN_*/DB_* env vars
 	@echo "🚀 Rendering test configuration from templates"
+	@# ~/.evn_test.yaml: legacy YAML config, used by the transfer_vn CLI (test_transfer_vn).
 	@envsubst '$(ENVSUBST_VARS)' < tests/data/evn_test.yaml.tmpl > $$HOME/.evn_test.yaml
-	@envsubst '$(ENVSUBST_VARS)' < tests/data/evn_test.toml.tmpl > $$HOME/.evn_test.toml
+	@# ~/evn_test.toml: read directly via Dynaconf by the test modules (no leading dot).
+	@envsubst '$(ENVSUBST_VARS)' < tests/data/evn_test.toml.tmpl > $$HOME/evn_test.toml
+	@# ~/.evn_test.toml: update_vn CLI config (test_update_vn write tests).
+	@envsubst '$(ENVSUBST_VARS)' < tests/data/evn_test_update.toml.tmpl > $$HOME/.evn_test.toml
 
 .PHONY: test-db
 test-db: ## Enable PostGIS extensions + app role, then create the database and tables

--- a/tests/data/evn_test.toml.tmpl
+++ b/tests/data/evn_test.toml.tmpl
@@ -1,8 +1,9 @@
-# Template for the single-site test configuration (~/.evn_test.toml).
-# Read directly via Dynaconf (test_download_vn, test_store_file,
-# test_store_postgresql).
+# Template for the single-site test configuration (~/evn_test.toml).
+# Read directly via Dynaconf by the test modules (test_biolovision_api,
+# test_download_vn, test_store_file, test_store_postgresql, test_update_vn),
+# which look up "evn_test.toml" from the pytest working directory upwards.
 # Render with envsubst, e.g.:
-#   envsubst < tests/data/evn_test.toml.tmpl > ~/.evn_test.toml
+#   envsubst < tests/data/evn_test.toml.tmpl > ~/evn_test.toml
 # Required variables: VN_SITE_URL VN_USER_EMAIL VN_USER_PW VN_CLIENT_KEY
 #   VN_CLIENT_SECRET DB_HOST DB_PORT DB_NAME DB_GROUP DB_USER DB_PW
 
@@ -13,9 +14,10 @@ type_date = "entry"
 start_date = 2019-08-01
 end_date = 2019-09-01
 
-[site.tff]
+[site]
+name = "tff"
 enabled = true
-site = "${VN_SITE_URL}"
+site_url = "${VN_SITE_URL}"
 user_email = "${VN_USER_EMAIL}"
 user_pw = "${VN_USER_PW}"
 client_key = "${VN_CLIENT_KEY}"

--- a/tests/data/evn_test_update.toml.tmpl
+++ b/tests/data/evn_test_update.toml.tmpl
@@ -1,0 +1,28 @@
+# Template for the update_vn CLI test configuration (~/.evn_test.toml).
+# Used by test_update_vn.py::test_update, which runs the update_vn CLI
+# against it (same structure as src/update_vn/data/evn_template.toml).
+# Render with envsubst, e.g.:
+#   envsubst < tests/data/evn_test_update.toml.tmpl > ~/.evn_test.toml
+# Required variables: VN_SITE_URL VN_USER_EMAIL VN_USER_PW VN_CLIENT_KEY
+#   VN_CLIENT_SECRET
+
+# Message added to hidden_comment after update
+message = "Modification en masse, le {date}, opération {op}, attribut {path}, depuis {old} vers {new}"
+
+[sites]
+# Connection details for each Biolovision site
+
+[sites.tff]
+site = "${VN_SITE_URL}"
+user_email = "${VN_USER_EMAIL}"
+user_pw = "${VN_USER_PW}"
+client_key = "${VN_CLIENT_KEY}"
+client_secret = "${VN_CLIENT_SECRET}"
+
+[tuning]
+max_list_length = 100
+max_chunks = 1000
+max_retry = 5
+max_requests = 0
+retry_delay = 5
+unavailable_delay = 600


### PR DESCRIPTION
  Problème

  La migration TOML des tests a changé ce que lisent les modules de test, sans que make test-config ne suive :

  - les tests chargent désormais evn_test.toml (sans point initial), alors que le Makefile générait ~/.evn_test.toml ;
  - ils attendent une section plate [site] (name, site_url, …), alors que le template tests/data/evn_test.toml.tmpl avait encore l'ancienne structure imbriquée [site.tff].

  Sans le fichier attendu, la collection pytest échoue sur 4 modules avec KeyError: 'SITE does not exist' — c'est ce qui bloquait les tests dans la stack docker.

  Modifications

  - tests/data/evn_test.toml.tmpl : réécrit avec la structure plate attendue par les tests, rendu vers ~/evn_test.toml ;
  - tests/data/evn_test_update.toml.tmpl (nouveau) : config pour le CLI update_vn (structure [sites.tff], identique à src/update_vn/data/evn_template.toml), rendue vers ~/.evn_test.toml, utilisée par
  test_update_vn::test_update ;
  - Makefile : test-config rend désormais les trois fichiers — ~/evn_test.toml (modules de test Dynaconf), ~/.evn_test.yaml (CLI transfer_vn), ~/.evn_test.toml (CLI update_vn).

  Validation

  Vérifié dans la stack docker compose : rendu des configs, création de la base via transfer_vn --db_drop --db_create --json_tables_create --col_tables_create, collection pytest depuis /root (81 tests 
  collectés, 0 erreur, contre 4 erreurs de collection avant), et tous les tests exécutables sans identifiants VN réels passent (test_store_file, test_update_vn init, test_increment_regression, test_transfer_vn
  -m "not slow"). Avec les variables VN_* exportées, make test-integration-docker déroule la suite complète.

  Suggestion (hors périmètre de cette PR) : unifier le schéma de configuration

  Cette PR corrige le symptôme, mais il coexiste aujourd'hui quatre schémas de configuration : le YAML legacy multi-site (evnconf.py/strictyaml), le TOML transfer_vn avec [site.xxx] imbriqué, le TOML update_vn
  avec [sites.xxx] (pluriel), et le TOML plat [site] lu par les tests — et aussi par les chemins --schedule/--update de transfer_vn (cf. le xfail dans test_transfer_vn.py).

  Proposition à discuter : converger vers un schéma TOML/Dynaconf unique, celui de transfer_vn avec [site.xxx] imbriqué (le multi-site est nécessaire ; update_vn pourrait lire le même fichier en exigeant un
  seul site enabled). template/convert_config.py fournit déjà la conversion YAML → TOML pour la migration des utilisateurs, avec une release de dépréciation avant de retirer strictyaml. Gains : un seul
  template de test, levée du xfail de test_transfer_vn, validation centralisée via les validators Dynaconf, deux dépendances en moins. Je peux ouvrir une issue dédiée si tu es partant.