### PR TITLE
Migrate store_postgresql to SQLAlchemy 2.0-style engine and transactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,9 @@ DB_USER ?= xfer38
 DB_PW ?= xfer38pw
 PGPASSWORD ?= postgres
 PYTEST_MARKERS ?= not slow and not privileged
+# Surface SQLAlchemy 2.0 deprecations; pytest escalates them to errors
+# (filterwarnings in pyproject.toml) to prevent 1.x-pattern regressions.
+export SQLALCHEMY_WARN_20 = 1
 export DB_HOST DB_PORT DB_NAME DB_GROUP DB_USER DB_PW
 
 # Variables substituted into the test configuration templates by envsubst.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,11 @@ ignore_errors = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+filterwarnings = [
+  # Guard against reintroducing SQLAlchemy 1.x patterns (needs SQLALCHEMY_WARN_20=1,
+  # exported by the Makefile test targets, to be emitted at all)
+  "error::sqlalchemy.exc.RemovedIn20Warning",
+]
 markers = [
   "slow: marks tests as slow (deselect with '-m \"not slow\"')",
   "write: marks tests that create/update/delete data on the live VisioNature site; skipped unless VN_ENABLE_WRITE_TESTS=1",
@@ -190,4 +195,5 @@ source = ["src"]
 known_first_party = ["biolovision", "export_vn"]
 
 [tool.deptry.per_rule_ignores]
-DEP002 = ["babel"]
+# psycopg2-binary: not imported directly, used as the SQLAlchemy driver
+DEP002 = ["babel", "psycopg2-binary"]

--- a/src/export_vn/store_postgresql.py
+++ b/src/export_vn/store_postgresql.py
@@ -14,7 +14,6 @@ Properties
 import logging
 from datetime import date
 
-from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from pyproj import Transformer
 from sqlalchemy import (
     BigInteger,
@@ -29,6 +28,7 @@ from sqlalchemy import (
     exc,
     func,
     select,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, insert
 from sqlalchemy.engine.url import URL
@@ -394,39 +394,39 @@ class PostgresqlUtils:
                 "port": self._db_port,
                 "database": "postgres",
             }
-            db = create_engine(URL.create(**db_url), echo=False)
-            conn = db.connect()
-            conn.connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+            db = create_engine(URL.create(**db_url), echo=False, future=True)
+            # CREATE/DROP DATABASE cannot run inside a transaction block
+            conn = db.connect().execution_options(isolation_level="AUTOCOMMIT")
 
             # Group role:
             logger.debug(_("Creating roles"))
-            text = f"""
+            sql = f"""
                 SELECT FROM pg_catalog.pg_roles WHERE rolname = '{self._db_group}'
                 """
-            result = conn.execute(text)
+            result = conn.execute(text(sql))
             row = result.fetchone()
             if row is None:
-                text = f"""
+                sql = f"""
                     CREATE ROLE {self._db_group} NOLOGIN NOSUPERUSER INHERIT NOCREATEDB
                     NOCREATEROLE NOREPLICATION
                     """
             else:
-                text = f"""
+                sql = f"""
                     ALTER ROLE {self._db_group} NOLOGIN NOSUPERUSER INHERIT NOCREATEDB
                     NOCREATEROLE NOREPLICATION
                     """
-            conn.execute(text)
+            conn.execute(text(sql))
 
             # Import role:
-            text = f"GRANT {self._db_group} TO {self._db_user}"
-            conn.execute(text)
+            sql = f"GRANT {self._db_group} TO {self._db_user}"
+            conn.execute(text(sql))
 
             # Create database:
             logger.debug(_("Creating database"))
-            text = f"CREATE DATABASE {self._db_name} WITH OWNER = {self._db_group}"
-            conn.execute(text)
-            text = f"GRANT ALL ON DATABASE {self._db_name} TO {self._db_group}"
-            conn.execute(text)
+            sql = f"CREATE DATABASE {self._db_name} WITH OWNER = {self._db_group}"
+            conn.execute(text(sql))
+            sql = f"GRANT ALL ON DATABASE {self._db_name} TO {self._db_group}"
+            conn.execute(text(sql))
             conn.close()
             db.dispose()
 
@@ -448,28 +448,28 @@ class PostgresqlUtils:
                 "port": self._db_port,
                 "database": "postgres",
             }
-            db = create_engine(URL.create(**db_url), echo=False)
-            conn = db.connect()
-            conn.connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+            db = create_engine(URL.create(**db_url), echo=False, future=True)
+            # CREATE/DROP DATABASE cannot run inside a transaction block
+            conn = db.connect().execution_options(isolation_level="AUTOCOMMIT")
 
             version = conn.dialect.server_version_info
             pid_column = "pid" if (version >= (9, 2)) else "procpid"
 
-            text = f"""
+            sql = f"""
             SELECT pg_terminate_backend(pg_stat_activity.{pid_column})
             FROM pg_stat_activity
             WHERE pg_stat_activity.datname = '{self._db_name}'
             AND {pid_column} <> pg_backend_pid();
             """  # noqa: S608
-            logger.debug(_("Dropping tables: %s"), text)
-            conn.execute(text)
-            text = f"DROP DATABASE IF EXISTS {self._db_name}"
-            logger.debug(_("Dropping database: %s"), text)
-            conn.execute(text)
+            logger.debug(_("Dropping tables: %s"), sql)
+            conn.execute(text(sql))
+            sql = f"DROP DATABASE IF EXISTS {self._db_name}"
+            logger.debug(_("Dropping database: %s"), sql)
+            conn.execute(text(sql))
             try:
-                text = f"DROP ROLE IF EXISTS {self._db_group}"
-                logger.debug(_("Dropping role: %s"), text)
-                conn.execute(text)
+                sql = f"DROP ROLE IF EXISTS {self._db_group}"
+                logger.debug(_("Dropping role: %s"), sql)
+                conn.execute(text(sql))
             except exc.SQLAlchemyError as e:
                 logger.warning(_("Error %s ignored when dropping role"), repr(e))
 
@@ -497,38 +497,32 @@ class PostgresqlUtils:
                 _("Connecting to %s database, to finalize creation"),
                 self._db_name,
             )
-            self._db = create_engine(URL.create(**db_url), echo=False)
-            conn = self._db.connect()
+            self._db = create_engine(URL.create(**db_url), echo=False, future=True)
+            with self._db.begin() as conn:
+                # Add extensions
+                logger.debug(_("Creating extensions"))
+                conn.execute(text("CREATE EXTENSION IF NOT EXISTS pgcrypto"))
+                conn.execute(text("CREATE EXTENSION IF NOT EXISTS adminpack"))
+                conn.execute(text('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'))
+                conn.execute(text("CREATE EXTENSION IF NOT EXISTS postgis"))
+                conn.execute(text("CREATE EXTENSION IF NOT EXISTS postgis_topology"))
 
-            # Add extensions
-            logger.debug(_("Creating extensions"))
-            text = "CREATE EXTENSION IF NOT EXISTS pgcrypto"
-            conn.execute(text)
-            text = "CREATE EXTENSION IF NOT EXISTS adminpack"
-            conn.execute(text)
-            text = 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'
-            conn.execute(text)
-            text = "CREATE EXTENSION IF NOT EXISTS postgis"
-            conn.execute(text)
-            text = "CREATE EXTENSION IF NOT EXISTS postgis_topology"
-            conn.execute(text)
+                # Create import schema
+                logger.debug(_("Creating import schema"))
+                sql = f"CREATE SCHEMA IF NOT EXISTS {self._db_schema_import} AUTHORIZATION {self._db_group}"
+                conn.execute(text(sql))
 
-            # Create import schema
-            logger.debug(_("Creating import schema"))
-            text = f"CREATE SCHEMA IF NOT EXISTS {self._db_schema_import} AUTHORIZATION {self._db_group}"
-            conn.execute(text)
-
-            # Enable privileges
-            text = """
-            ALTER DEFAULT PRIVILEGES
-            GRANT INSERT, SELECT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLES
-            TO postgres"""
-            conn.execute(text)
-            text = f"""
-            ALTER DEFAULT PRIVILEGES
-            GRANT INSERT, SELECT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLES
-            TO {self._db_group}"""
-            conn.execute(text)
+                # Enable privileges
+                sql = """
+                ALTER DEFAULT PRIVILEGES
+                GRANT INSERT, SELECT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLES
+                TO postgres"""
+                conn.execute(text(sql))
+                sql = f"""
+                ALTER DEFAULT PRIVILEGES
+                GRANT INSERT, SELECT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLES
+                TO {self._db_group}"""
+                conn.execute(text(sql))
 
             # Set path to include VN import schema
             dbschema = self._db_schema_import
@@ -553,7 +547,6 @@ class PostgresqlUtils:
             self._create_territorial_units_json()
             self._create_validations_json()
 
-            conn.close()
             self._db.dispose()
 
         return None
@@ -581,19 +574,19 @@ class PostgresqlUtils:
 
             # Connect and set path to include VN import schema
             logger.info(_("Connecting to database %s"), self._db_name)
-            self._db = create_engine(URL.create(**db_url), echo=False)
-            conn = self._db.connect()
+            self._db = create_engine(URL.create(**db_url), echo=False, future=True)
             dbschema = self._db_schema_import
             self._metadata = MetaData(schema=dbschema)
             # self._metadata.reflect(self._db)
 
-            text = f"""
+            sql = f"""
             SELECT site, ((item->>0)::json->'species') ->> 'taxonomy' AS taxonomy, COUNT(id)
                 FROM {dbschema}.observations_json
                 GROUP BY site, ((item->>0)::json->'species') ->> 'taxonomy';
             """  # noqa: S608
 
-            result = conn.execute(text).fetchall()
+            with self._db.connect() as conn:
+                result = conn.execute(text(sql)).fetchall()
 
         return result
 
@@ -620,13 +613,12 @@ class PostgresqlUtils:
 
             # Connect and set path to include VN import schema
             logger.info(_("Connecting to database %s"), self._db_name)
-            self._db = create_engine(URL.create(**db_url), echo=False)
-            conn = self._db.connect()
+            self._db = create_engine(URL.create(**db_url), echo=False, future=True)
             dbschema = self._db_schema_vn
             self._metadata = MetaData(schema=dbschema)
             # self._metadata.reflect(self._db)
 
-            text = f"""
+            sql = f"""
             SELECT o.site, o.taxonomy, t.name, COUNT(o.id_sighting)
                 FROM {dbschema}.observations AS o
                     LEFT JOIN {dbschema}.taxo_groups AS t
@@ -634,7 +626,8 @@ class PostgresqlUtils:
                 GROUP BY o.site, o.taxonomy, t.name
             """  # noqa: S608
 
-            result = conn.execute(text).fetchall()
+            with self._db.connect() as conn:
+                result = conn.execute(text(sql)).fetchall()
 
         return result
 
@@ -684,7 +677,7 @@ class Postgresql:
             logger.info(_("Connecting to database %s"), self._db_name)
 
             # Connect and set path to include VN import schema
-            self._db = create_engine(URL.create(**db_url), echo=False)
+            self._db = create_engine(URL.create(**db_url), echo=False, future=True)
             self._conn = self._db.connect()
 
             # Get dbtable definition
@@ -772,8 +765,11 @@ class ReadPostgresql(Postgresql):
             self._site,
         )
         metadata = self._table_defs[controler]["metadata"]
-        stmt = select([metadata.c.item]).where(metadata.c.site == self._site)
-        return self._conn.execute(stmt).fetchall()
+        stmt = select(metadata.c.item).where(metadata.c.site == self._site)
+        result = self._conn.execute(stmt).fetchall()
+        # Release the transaction implicitly started by the SELECT
+        self._conn.rollback()
+        return result
 
 
 class StorePostgresql(Postgresql):
@@ -1093,19 +1089,26 @@ class StorePostgresql(Postgresql):
         nb_item = 0
         # Store to database, if enabled
         if self._db_enabled:
-            if self._table_defs[controler]["type"] == "observation":
-                nb_item = self._store_observation(controler, items_dict)
-            elif self._table_defs[controler]["type"] == "simple":
-                nb_item = self._store_simple(controler, items_dict)
-            elif self._table_defs[controler]["type"] == "geometry":
-                nb_item = self._store_geometry(controler, items_dict)
-            elif self._table_defs[controler]["type"] == "observers":
-                nb_item = self._store_observers(controler, items_dict)
-            elif self._table_defs[controler]["type"] == "fields":
-                nb_item = self._store_fields(controler, items_dict)
-
-            else:
+            controler_type = self._table_defs[controler]["type"]
+            if controler_type not in {"observation", "simple", "geometry", "observers", "fields"}:
                 raise StorePostgresqlException(_("Not implemented"))
+            # The whole sequence is committed at once: on error, the partial
+            # batch is rolled back instead of leaving half-stored data behind.
+            try:
+                if controler_type == "observation":
+                    nb_item = self._store_observation(controler, items_dict)
+                elif controler_type == "simple":
+                    nb_item = self._store_simple(controler, items_dict)
+                elif controler_type == "geometry":
+                    nb_item = self._store_geometry(controler, items_dict)
+                elif controler_type == "observers":
+                    nb_item = self._store_observers(controler, items_dict)
+                elif controler_type == "fields":
+                    nb_item = self._store_fields(controler, items_dict)
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
 
         return nb_item
 
@@ -1128,16 +1131,21 @@ class StorePostgresql(Postgresql):
             logger.info(_("Deleting %d observations from database"), len(obs_list))
             nb_delete = 0
             obs_table = self._table_defs["observations"]["metadata"]
-            for obs in obs_list:
-                nd = self._conn.execute(
-                    obs_table.delete().where(
-                        and_(
-                            obs_table.c.id == obs,
-                            obs_table.c.site == self._site,
+            try:
+                for obs in obs_list:
+                    nd = self._conn.execute(
+                        obs_table.delete().where(
+                            and_(
+                                obs_table.c.id == obs,
+                                obs_table.c.site == self._site,
+                            )
                         )
                     )
-                )
-                nb_delete += nd.rowcount
+                    nb_delete += nd.rowcount
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
 
         return nb_delete
 
@@ -1160,16 +1168,21 @@ class StorePostgresql(Postgresql):
             logger.info(_("Deleting %d places from database"), len(place_list))
             nb_delete = 0
             place_table = self._table_defs["places"]["metadata"]
-            for obs in place_list:
-                nd = self._conn.execute(
-                    place_table.delete().where(
-                        and_(
-                            place_table.c.id == obs,
-                            place_table.c.site == self._site,
+            try:
+                for obs in place_list:
+                    nd = self._conn.execute(
+                        place_table.delete().where(
+                            and_(
+                                place_table.c.id == obs,
+                                place_table.c.site == self._site,
+                            )
                         )
                     )
-                )
-                nb_delete += nd.rowcount
+                    nb_delete += nd.rowcount
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
 
         return nb_delete
 
@@ -1214,7 +1227,12 @@ class StorePostgresql(Postgresql):
                 length=length,
                 duration=duration,
             )
-            self._conn.execute(stmt)
+            try:
+                self._conn.execute(stmt)
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
 
         return None
 
@@ -1239,7 +1257,12 @@ class StorePostgresql(Postgresql):
                 constraint=metadata.primary_key,
                 set_=dict(last_ts=last_ts),  # noqa: C408
             )
-            self._conn.execute(do_update_stmt)
+            try:
+                self._conn.execute(do_update_stmt)
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
 
         return None
 
@@ -1262,11 +1285,11 @@ class StorePostgresql(Postgresql):
         # Store to database, if enabled
         if self._db_enabled:
             metadata = self._metadata.tables[self._db_schema_import + "." + "increment_log"]
-            stmt = select([metadata.c.last_ts]).where(
-                and_(metadata.c.taxo_group == taxo_group, metadata.c.site == site)
-            )
+            stmt = select(metadata.c.last_ts).where(and_(metadata.c.taxo_group == taxo_group, metadata.c.site == site))
             result = self._conn.execute(stmt)
             row = result.fetchone()
+            # Release the transaction implicitly started by the SELECT
+            self._conn.rollback()
 
         if row is None:
             return None

--- a/tests/test_store_postgresql_transactions.py
+++ b/tests/test_store_postgresql_transactions.py
@@ -1,0 +1,140 @@
+"""
+Test the transactional behavior of store_postgresql (SQLAlchemy 2.0 semantics).
+
+These tests only need the PostGIS database (tables created by
+`transfer_vn --json_tables_create --col_tables_create`), no VisioNature
+account: data is injected directly through the store API.
+
+They cover the behavior introduced by the SQLAlchemy 2.0 migration:
+- store() commits per batch and rolls the whole batch back on error;
+- the connection stays usable after a failed batch;
+- committed data is visible from other connections;
+- read() and increment_get() do not leave the connection 'idle in transaction'.
+"""
+
+import pytest
+from dynaconf import Dynaconf
+from sqlalchemy import create_engine, exc, text
+from sqlalchemy.engine.url import URL
+
+from export_vn.store_postgresql import ReadPostgresql, StorePostgresql
+
+FILE = "evn_test.toml"
+
+# Get configuration for test site
+settings = Dynaconf(
+    settings_files=[FILE],
+)
+
+# Test ids, far above any real VisioNature id, cleaned up after each test
+TEST_IDS = [999999901, 999999902]
+
+
+def _pg_params():
+    return dict(  # noqa: C408
+        site=settings["SITE"]["name"],
+        db_enabled=settings["DATABASE"]["enabled"],
+        db_user=settings["DATABASE"]["db_user"],
+        db_pw=settings["DATABASE"]["db_pw"],
+        db_host=settings["DATABASE"]["db_host"],
+        db_port=settings["DATABASE"]["db_port"],
+        db_name=settings["DATABASE"]["db_name"],
+        db_schema_import=settings["DATABASE"]["db_schema_import"],
+        db_schema_vn=settings["DATABASE"]["db_schema_vn"],
+        db_group=settings["DATABASE"]["db_group"],
+        db_out_proj=settings["DATABASE"]["db_out_proj"],
+    )
+
+
+@pytest.fixture(scope="module")
+def monitor():
+    """Independent engine, to observe the database from a separate connection."""
+    db_url = {
+        "drivername": "postgresql+psycopg2",
+        "username": settings["DATABASE"]["db_user"],
+        "password": settings["DATABASE"]["db_pw"],
+        "host": settings["DATABASE"]["db_host"],
+        "port": settings["DATABASE"]["db_port"],
+        "database": settings["DATABASE"]["db_name"],
+    }
+    db = create_engine(URL.create(**db_url), echo=False, future=True)
+    yield db
+    db.dispose()
+
+
+@pytest.fixture()
+def store_pg(monitor):
+    """A fresh store, with test rows cleaned up on teardown."""
+    store = StorePostgresql(**_pg_params())
+    yield store
+    store.__exit__(None, None, None)
+    schema = settings["DATABASE"]["db_schema_import"]
+    with monitor.begin() as conn:
+        conn.execute(
+            text(f"DELETE FROM {schema}.entities_json WHERE id = ANY(:ids)"),  # noqa: S608
+            {"ids": TEST_IDS},
+        )
+
+
+def _count_test_rows(monitor):
+    schema = settings["DATABASE"]["db_schema_import"]
+    with monitor.connect() as conn:
+        return conn.execute(
+            text(f"SELECT COUNT(*) FROM {schema}.entities_json WHERE id = ANY(:ids)"),  # noqa: S608
+            {"ids": TEST_IDS},
+        ).scalar()
+
+
+def test_store_commits_batch(store_pg, monitor):
+    """A stored batch must be committed, i.e. visible from another connection."""
+    items = {"data": [{"id": TEST_IDS[0], "short_name": "pytest entity"}]}
+    assert store_pg.store("entities", "1", items) == 1
+    assert _count_test_rows(monitor) == 1
+
+
+def test_store_rolls_back_failed_batch(store_pg, monitor):
+    """On error, the whole batch is rolled back, and the connection stays usable."""
+    bad_batch = {
+        "data": [
+            {"id": TEST_IDS[0], "short_name": "stored before the error"},
+            {"id": None, "short_name": "violates NOT NULL"},
+        ]
+    }
+    with pytest.raises(exc.SQLAlchemyError):
+        store_pg.store("entities", "1", bad_batch)
+    # The first, valid element must not survive the failed batch
+    assert _count_test_rows(monitor) == 0
+
+    # The connection must remain usable after the rollback
+    items = {"data": [{"id": TEST_IDS[1], "short_name": "stored after the error"}]}
+    assert store_pg.store("entities", "1", items) == 1
+    assert _count_test_rows(monitor) == 1
+
+
+def _backend_state(monitor, backend_pid):
+    with monitor.connect() as conn:
+        return conn.execute(
+            text("SELECT state FROM pg_stat_activity WHERE pid = :pid"),
+            {"pid": backend_pid},
+        ).scalar()
+
+
+def _backend_pid(pg):
+    pid = pg._conn.execute(text("SELECT pg_backend_pid()")).scalar()
+    pg._conn.rollback()
+    return pid
+
+
+def test_reads_release_transaction(store_pg, monitor):
+    """read() and increment_get() must not leave the connection 'idle in transaction'."""
+    read_pg = ReadPostgresql(**_pg_params())
+    try:
+        read_pid = _backend_pid(read_pg)
+        read_pg.read("entities")
+        assert _backend_state(monitor, read_pid) == "idle"
+    finally:
+        read_pg.__exit__(None, None, None)
+
+    store_pid = _backend_pid(store_pg)
+    store_pg.increment_get(settings["SITE"]["name"], 1)
+    assert _backend_state(monitor, store_pid) == "idle"


### PR DESCRIPTION
  **Objectif**

Préparer l'abandon des vieilles dépendances en migrant la couche de persistance vers les sémantiques SQLAlchemy 2.0. L'inventaire (SQLALCHEMY_WARN_20=1 sur la suite de tests dans la stack docker) a montré que tout se concentre dans src/export_vn/store_postgresql.py : ~30 RemovedIn20Warning sur 18 sites, plus deux select([...]) (forme supprimée en 2.0) non détectés dynamiquement.

Les moteurs sont créés avec future=True : le code adopte les sémantiques 2.0 tout en tournant sous 1.4. Le pin SQLAlchemy<2 est conservé, le lever devient un simple bump de version dans une PR de suivi, sans changement de code. (APScheduler 3.11 est compatible SQLAlchemy 2 depuis la 3.10 ; le pin apscheduler<4 reste, la v4 étant une réécriture complète.)

Refs #340

  **Modifications**

- text() sur tout le SQL brut : create_database, drop_database, create_json_tables, count_json_obs, count_col_obs. La variable locale text est renommée sql (elle masquait la construction SQLAlchemy).
- Autocommit explicite : conn.connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT) (psycopg2 bas-niveau) remplacé par execution_options(isolation_level="AUTOCOMMIT") pour CREATE/DROP DATABASE ; le DDL de create_json_tables passe dans un bloc with engine.begin(). Plus d'import direct de psycopg2 (ajouté à l'ignore deptry DEP002, il reste le driver).
- Transactions explicites sur la connexion longue durée : chaque méthode d'écriture (store, delete_obs, delete_place, log, increment_log) committe en fin d'opération et rollback sur erreur. store() committe par lot : une erreur en cours de batch annule tout le lot au lieu de laisser des données à moitié écrites, et la connexion reste utilisable ensuite (plus de « current transaction is aborted »). Ce comportement recoupe le chantier « pertes de données en cas d'erreur de téléchargement » (#396).
- select([...]) → select(...) dans read() et increment_get().
 
- Hygiène, sans lien de causalité avec la migration : libération (rollback()) des transactions implicitement ouvertes par les SELECT dans read() et increment_get(). Le problème préexistait en 1.4 : après une lecture, la connexion longue durée restait idle in transaction entre deux réveils du scheduler, retenant son snapshot (ce qui bloque VACUUM et favorise le bloat sur les longues exécutions de --schedule).
Vérifié via pg_stat_activity : idle in transaction après un SELECT, idle après le rollback().

**Validation**

Dans la stack docker compose, avec SQLALCHEMY_WARN_20=1 :

- cycle complet transfer_vn --db_drop --db_create --json_tables_create --col_tables_create ✔ (chemins AUTOCOMMIT exercés)
- 0 RemovedIn20Warning sur la suite hors réseau (30 avant), résultats de tests identiques à main (aucune régression)
- 3 nouveaux tests (test_store_postgresql_transactions.py, base seule, sans compte VN, #91) verrouillent les changements de comportement : commit par lot visible d'une autre connexion, rollback intégral d'un lot en échec + connexion réutilisable, et libération des transactions après lecture (pg_stat_activity). Ces tests échouent sur le code pré-migration.

Les chemins de stockage alimentés par l'API réelle (test_store_postgresql complet, test_download_vn) sont couverts par la CI d'intégration de cette PR.

**Changements de comportement à noter en revue**

1. Commit par lot dans store() (remplace l'autocommit par observation) : en cas d'erreur au milieu d'un batch, plus rien n'est persisté pour ce batch (avant : les éléments déjà traités restaient en base).
C'est voulu, cohérence du lot et connexion saine, mais c'est le point à valider en priorité.
2. Transactions refermées après les lectures : la connexion ne reste plus idle in transaction après read()/increment_get() (cf. puce « Hygiène » ci-dessus).

Refs #340 (migration du code ; le pin <2 sera levé dans une PR de suivi qui fermera l'issue), #91 (nouveaux tests du store sans download_vn), #396 / #169 (le commit par lot supprime les écritures partielles en cas d'erreur, prérequis au chantier pertes de données, sans corriger la cause côté téléchargement).